### PR TITLE
Fixes race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ for bar := range bars {
 # Reference
 
 * [API Documentation](https://interactivebrokers.github.io/tws-api/)
+
+# Development
+
+* [Publish Module](https://go.dev/doc/modules/publishing)

--- a/transport.go
+++ b/transport.go
@@ -45,7 +45,7 @@ func (b *TcpMessageBus) Close() error {
 func (b *TcpMessageBus) Write(data string) error {
 	_, err := b.socket.Write([]byte(data))
 	if err != nil {
-		return err
+		return stacktrace.Propagate(err, "error writing bytes")
 	}
 
 	return nil
@@ -58,7 +58,7 @@ func (b *TcpMessageBus) WritePacket(data string) error {
 
 	_, err := b.socket.Write(header)
 	if err != nil {
-		return err
+		return stacktrace.Propagate(err, "error writing packet")
 	}
 
 	_, err = b.socket.Write([]byte(data))
@@ -74,7 +74,7 @@ func (b *TcpMessageBus) ReadPacket() (string, error) {
 	header := make([]byte, 4)
 	_, err := io.ReadFull(b.socket, header)
 	if err != nil {
-		return "", err
+		return "", stacktrace.Propagate(err, "error reading packet header")
 	}
 
 	size := binary.BigEndian.Uint32(header)
@@ -82,7 +82,7 @@ func (b *TcpMessageBus) ReadPacket() (string, error) {
 	data := make([]byte, size)
 	_, err = io.ReadFull(b.socket, data)
 	if err != nil {
-		return "", err
+		return "", stacktrace.Propagate(err, "error reading packet body")
 	}
 
 	return string(data), nil


### PR DESCRIPTION
Wait for server to send next valid order id before sending requests.

Sending requests prior to this may cause the server to close the connection.